### PR TITLE
Update for 0.4 deprecations

### DIFF
--- a/src/fixed32.jl
+++ b/src/fixed32.jl
@@ -33,13 +33,13 @@ abs{f}(x::Fixed32{f}) = Fixed32{f}(abs(x.i),0)
 # with truncation:
 #*{f}(x::Fixed32{f}, y::Fixed32{f}) = Fixed32{f}(Base.widemul(x.i,y.i)>>f,0)
 # with rounding up:
-*{f}(x::Fixed32{f}, y::Fixed32{f}) = Fixed32{f}((Base.widemul(x.i,y.i)+(int64(1)<<(f-1)))>>f,0)
+*{f}(x::Fixed32{f}, y::Fixed32{f}) = Fixed32{f}((Base.widemul(x.i,y.i)+(convert(Int64, 1)<<(f-1)))>>f,0)
 
-/{f}(x::Fixed32{f}, y::Fixed32{f}) = Fixed32{f}(div(int64(x.i)<<f, y.i),0)
+/{f}(x::Fixed32{f}, y::Fixed32{f}) = Fixed32{f}(div(convert(Int64, x.i)<<f, y.i),0)
 
 # conversions and promotions
 convert{f}(::Type{Fixed32{f}}, x::Integer) = Fixed32{f}(x<<f,0)
-convert{f}(::Type{Fixed32{f}}, x::FloatingPoint) = Fixed32{f}(trunc(Int32,x)<<f + int32(rem(x,1)*(1<<f)),0)
+convert{f}(::Type{Fixed32{f}}, x::FloatingPoint) = Fixed32{f}(trunc(Int32,x)<<f + round(Int32, rem(x,1)*(1<<f)),0)
 convert{f}(::Type{Fixed32{f}}, x::Rational) = Fixed32{f}(x.num)/Fixed32{f}(x.den)
 
 convert{f}(::Type{BigFloat}, x::Fixed32{f}) =

--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -82,10 +82,10 @@ sizeof{T<:Ufixed}(::Type{T}) = sizeof(rawtype(T))
 abs(x::Ufixed) = x
 
 # Arithmetic
-+{T,f}(x::UfixedBase{T,f}, y::UfixedBase{T,f}) = float32(x)+float32(y) # UfixedBase{T,f}(convert(T, reinterpret(x)+reinterpret(y)),0)
--{T,f}(x::UfixedBase{T,f}, y::UfixedBase{T,f}) = float32(x)-float32(y) # UfixedBase{T,f}(convert(T, reinterpret(x)-reinterpret(y)),0)
-*{T,f}(x::UfixedBase{T,f}, y::UfixedBase{T,f}) = float32(x)*float32(y)
-/(x::Ufixed, y::Ufixed) = float32(x)/float32(y)
++{T,f}(x::UfixedBase{T,f}, y::UfixedBase{T,f}) = convert(Float32, x)+convert(Float32, y) # UfixedBase{T,f}(convert(T, reinterpret(x)+reinterpret(y)),0)
+-{T,f}(x::UfixedBase{T,f}, y::UfixedBase{T,f}) = convert(Float32, x)-convert(Float32, y) # UfixedBase{T,f}(convert(T, reinterpret(x)-reinterpret(y)),0)
+*{T,f}(x::UfixedBase{T,f}, y::UfixedBase{T,f}) = convert(Float32, x)*convert(Float32, y)
+/(x::Ufixed, y::Ufixed) = convert(Float32, x)/convert(Float32, y)
 
 # Comparisons
 < {T<:Ufixed}(x::T, y::T) = reinterpret(x) <  reinterpret(y)
@@ -158,7 +158,7 @@ for T in UF
         promote_rule{TR<:Rational}(::Type{$T}, ::Type{TR}) = TR
     end
     for Ti in (Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64)
-        Tp = eps(float32(typemax(Ti))) > eps(T) ? Float64 : Float32
+        Tp = eps(convert(Float32, typemax(Ti))) > eps(T) ? Float64 : Float32
         @eval begin
             promote_rule(::Type{$T}, ::Type{$Ti}) = $Tp
         end

--- a/test/fixed32.jl
+++ b/test/fixed32.jl
@@ -2,24 +2,24 @@ using Base.Test
 using FixedPointNumbers
 
 function test_fixed{T}(::Type{T}, f)
-    values = [-10:0.01:10, -180:.01:-160, 160:.01:180]
+    values = [-10:0.01:10; -180:.01:-160; 160:.01:180]
     tol = 2.0^-f
 
     for x in values
         #isinteger(x) && @show x
         fx = convert(T,x)
-        @test convert(T,float64(fx)) == fx
-        @test convert(T,float64(-fx)) == -fx
-        @test float64(-fx) == -float64(fx)
+        @test convert(T,convert(Float64, fx)) == fx
+        @test convert(T,convert(Float64, -fx)) == -fx
+        @test convert(Float64, -fx) == -convert(Float64, fx)
 
-        fxf = float64(fx)
+        fxf = convert(Float64, fx)
 
         rx = convert(Rational{BigInt},fx)
         @assert isequal(fx,rx) == isequal(hash(fx),hash(rx))
 
         for y in values
             fy = convert(T,y)
-            fyf = float64(fy)
+            fyf = convert(Float64, fy)
 
             @assert fx==fy || x!=y
             @assert fx<fy  || x>=y
@@ -32,11 +32,11 @@ function test_fixed{T}(::Type{T}, f)
                 @assert abs((fx/fy)-convert(T,fxf/fyf)) <= tol
             end
 
-            @assert abs(float64(fx+fy)-(fxf+fyf)) <= tol
-            @assert abs(float64(fx-fy)-(fxf-fyf)) <= tol
-            @assert abs(float64(fx*fy)-(fxf*fyf)) <= tol
+            @assert abs(convert(Float64, fx+fy)-(fxf+fyf)) <= tol
+            @assert abs(convert(Float64, fx-fy)-(fxf-fyf)) <= tol
+            @assert abs(convert(Float64, fx*fy)-(fxf*fyf)) <= tol
             if fy != 0
-                @assert abs(float64(fx/fy)-(fxf/fyf)) <= tol
+                @assert abs(convert(Float64, fx/fy)-(fxf/fyf)) <= tol
             end
 
             @assert isequal(fx,fy) == isequal(hash(fx),hash(fy))

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -1,4 +1,4 @@
-using FixedPointNumbers, Base.Test
+using FixedPointNumbers, Compat, Base.Test
 
 @test reinterpret(0xa2uf8)  == 0xa2
 @test reinterpret(0xa2uf10) == 0xa2
@@ -65,17 +65,17 @@ for T in FixedPointNumbers.UF
     @test y > x
     @test y != x
     @test_approx_eq(x+y, T(0x35,0))
-    @test_approx_eq((x+y)-x, float32(y))
-    @test_approx_eq((x-y)+y, float32(x))
-    @test_approx_eq(x*y, float32(x)*float32(y))
-    @test_approx_eq(x/y, float32(x)/float32(y))
-    @test_approx_eq(x^2, float32(x)^2)
-    @test_approx_eq(x^2.1f0, float32(x)^2.1f0)
-    @test_approx_eq(x^2.1, float64(x)^2.1)
+    @test_approx_eq((x+y)-x, convert(Float32, y))
+    @test_approx_eq((x-y)+y, convert(Float32, x))
+    @test_approx_eq(x*y, convert(Float32, x)*convert(Float32, y))
+    @test_approx_eq(x/y, convert(Float32, x)/convert(Float32, y))
+    @test_approx_eq(x^2, convert(Float32, x)^2)
+    @test_approx_eq(x^2.1f0, convert(Float32, x)^2.1f0)
+    @test_approx_eq(x^2.1, convert(Float64, x)^2.1)
 end
 
 function testtrunc{T}(inc::T)
-    incf = float64(inc)
+    incf = convert(Float64, inc)
     tm = reinterpret(typemax(T))/reinterpret(one(T))
     x = zero(T)
     for i = 0:reinterpret(typemax(T))-1
@@ -111,7 +111,7 @@ x = 0xaauf8
 iob = IOBuffer()
 show(iob, x)
 str = takebuf_string(iob)
-@test beginswith(str, "Ufixed8(")
+@test startswith(str, "Ufixed8(")
 @test eval(parse(str)) == x
 
 # scaledual


### PR DESCRIPTION
This fixes deprecation warnings with current master. Presumably more changes should be made too, for example `ufixed8` should become `Ufixed8`. Or would you prefer to rename the types `UFixed8`?

A bigger question is: with the overhaul of arithmetic in julia 0.4, is it now time to switch the return type for `+` and `-` to a fixed-point type? Those are at least closed ~~and 1-to-1~~ under those operations (with overflow, of course).

The harder case is multiplication. Here's a demo showing why:
```julia
julia> a = ufixed8(0.1)
Ufixed8(0.102)

julia> a.i
0x1a

julia> b = ufixed16(a*a)
Ufixed16(0.01039)

julia> b.i
0x02a9

julia> 0x1a*0x1a
0xa4

julia> 0x001a*0x001a
0x02a4
```
So the low byte of the correct answer ends up in the high byte of the multiplicand of the underlying raw `UInteger`. We'd have to bit-shift and promote to `Ufixed16` even to represent the (overflowing) result properly. So unlike `UInt8`, `Ufixed8` multiplication is not closed. Leave it as `Float32`?
