### PR TITLE
Fix reductions so they don't overflow

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -60,6 +60,11 @@ include("ufixed.jl")
 include("deprecations.jl")
 
 
+# Promotions for reductions
+for F in (Base.AddFun, Base.MulFun)
+    @eval Base.r_promote{T}(::$F, x::FixedPoint{T}) = Float64(x)
+end
+
 # TODO: rewrite this by @generated
 for T in tuple(Fixed16, UF...)
     R = rawtype(T)

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -53,3 +53,16 @@ for (TI, f) in [(Int8, 8), (Int16, 8), (Int16, 10), (Int32, 16)]
     println("  Testing $T")
     test_fixed(T, f)
 end
+
+# reductions
+F8 = Fixed{Int8,8}
+a = F8[0.498, 0.1]
+acmp = Float64(a[1]) + Float64(a[2])
+@test sum(a) == acmp
+@test sum(a, 1) == [acmp]
+
+F6 = Fixed{Int8,6}
+a = F6[1.2, 1.4]
+acmp = Float64(a[1])*Float64(a[2])
+@test prod(a) == acmp
+@test prod(a, 1) == [acmp]

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -153,3 +153,6 @@ b, ad = scaledual(0.5, ad)
 generic_scale!(rfloat, a, 0.5)
 generic_scale!(rfixed, ad, b)
 @test rfloat == rfixed
+
+a = UFixed8[0xffuf8, 0xffuf8]
+@test sum(a) == 2.0

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -154,5 +154,12 @@ generic_scale!(rfloat, a, 0.5)
 generic_scale!(rfixed, ad, b)
 @test rfloat == rfixed
 
+# reductions
 a = UFixed8[0xffuf8, 0xffuf8]
 @test sum(a) == 2.0
+@test sum(a, 1) == [2.0]
+
+a = UFixed14[3.2, 2.4]
+acmp = Float64(a[1])*Float64(a[2])
+@test prod(a) == acmp
+@test prod(a, 1) == [acmp]


### PR DESCRIPTION
Base julia widens small integers when performing reductions. This PR implements this behavior for FixedPoint types. Necessitated by #27. CC @vchuravy.