### PR TITLE
Eliminate Compat dependency

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.4-
-Compat 0.2.2
+julia 0.4

--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -1,8 +1,6 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__()
+__precompile__()
 
 module FixedPointNumbers
-
-using Compat
 
 using Base: IdFun, AddFun, MulFun, reducedim_initarray
 
@@ -87,9 +85,9 @@ end
 # Particularly useful for arrays.
 scaledual(Tdual::Type, x) = one(Tdual), x
 scaledual{Tdual<:Number}(b::Tdual, x) = b, x
-@compat scaledual{T<:FixedPoint}(Tdual::Type, x::Union{T,AbstractArray{T}}) =
+scaledual{T<:FixedPoint}(Tdual::Type, x::Union{T,AbstractArray{T}}) =
     convert(Tdual, 1/one(T)), reinterpret(rawtype(T), x)
-@compat scaledual{Tdual<:Number, T<:FixedPoint}(b::Tdual, x::Union{T,AbstractArray{T}}) =
+scaledual{Tdual<:Number, T<:FixedPoint}(b::Tdual, x::Union{T,AbstractArray{T}}) =
     convert(Tdual, b/one(T)), reinterpret(rawtype(T), x)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-for f in ["fixed.jl", "ufixed.jl"]
+for f in ["ufixed.jl", "fixed.jl"]
     println("Testing $f")
     include(f)
 end

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -1,4 +1,4 @@
-using FixedPointNumbers, Compat, Base.Test
+using FixedPointNumbers, Base.Test
 
 @test reinterpret(0xa2uf8)  == 0xa2
 @test reinterpret(0xa2uf10) == 0xa2


### PR DESCRIPTION
Now that we're committed to 0.4, Compat is no longer necessary.