### PR TITLE
Explicitly import Base.minmax

### DIFF
--- a/src/FixedPointNumbers.jl
+++ b/src/FixedPointNumbers.jl
@@ -9,7 +9,7 @@ import Base: ==, <, <=, -, +, *, /, ~,
              isnan, isinf, isfinite,
              zero, one, typemin, typemax, realmin, realmax, eps, sizeof, reinterpret,
              trunc, round, floor, ceil, bswap,
-             div, fld, rem, mod, mod1, rem1, fld1, min, max,
+             div, fld, rem, mod, mod1, rem1, fld1, min, max, minmax,
              start, next, done, r_promote, reducedim_init
 # T => BaseType
 # f => Number of Bytes reserved for fractional part


### PR DESCRIPTION
Fixes this error:

```julia
julia> using FixedPointNumbers
INFO: Recompiling stale cache file /home/schmrlng/.julia/lib/v0.5/FixedPointNumbers.ji for module FixedPointNumbers.
ERROR: LoadError: LoadError: error in method definition: function Base.minmax must be explicitly imported to be extended
 in include(::UTF8String) at ./boot.jl:264
 in include_from_node1(::ASCIIString) at ./loading.jl:417
 in include(::ASCIIString) at ./boot.jl:264
 in include_from_node1(::ASCIIString) at ./loading.jl:417
 in eval(::Module, ::Any) at ./boot.jl:267
 [inlined code] from ./sysimg.jl:14
 in process_options(::Base.JLOptions) at ./client.jl:239
 in _start() at ./client.jl:318
while loading /home/schmrlng/.julia/v0.5/FixedPointNumbers/src/ufixed.jl, in expression starting on line 131
while loading /home/schmrlng/.julia/v0.5/FixedPointNumbers/src/FixedPointNumbers.jl, in expression starting on line 59
ERROR: Failed to precompile FixedPointNumbers to /home/schmrlng/.julia/lib/v0.5/FixedPointNumbers.ji
 in error(::ASCIIString) at ./error.jl:21
 in compilecache(::ASCIIString) at ./loading.jl:496
 in recompile_stale(::Symbol, ::UTF8String) at ./loading.jl:572
 in _require_from_serialized(::Int64, ::Symbol, ::UTF8String, ::Bool) at ./loading.jl:164
 in _require_from_serialized(::Int64, ::Symbol, ::Bool) at ./loading.jl:193
 in require(::Symbol) at ./loading.jl:323
 in eval(::Module, ::Any) at ./boot.jl:267
```