### PR TITLE
Make conversions work for Float16 (and speed tests)

### DIFF
--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -67,7 +67,10 @@ ufixed16(x) = convert(UFixed16, x)
 
 
 convert(::Type{BigFloat}, x::UFixed) = reinterpret(x)*(1/BigFloat(rawone(x)))
-convert{T<:AbstractFloat}(::Type{T}, x::UFixed) = reinterpret(x)*(1/convert(T, rawone(x)))
+function convert{T<:AbstractFloat}(::Type{T}, x::UFixed)
+    y = reinterpret(x)*(1/convert(T, rawone(x)))
+    convert(T, y)  # needed for types like Float16 which promote arithmetic to Float32
+end
 convert(::Type{Bool}, x::UFixed) = x == zero(x) ? false : true
 convert{T<:Integer}(::Type{T}, x::UFixed) = convert(T, x*(1/one(T)))
 convert{Ti<:Integer}(::Type{Rational{Ti}}, x::UFixed) = convert(Ti, reinterpret(x))//convert(Ti, rawone(x))

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -33,7 +33,7 @@ function test_fixed{T}(::Type{T}, f)
             @test fx<fy  || x>=y
             @test fx<=fy || x>y
 
-            for fun in [+, -, *, /]
+            for fun in (+, -, *, /)
                 # Make sure that the result is representable
                 if !(typemin(T) <= fun(fxf, fyf) <= typemax(T))
                     continue

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -4,8 +4,8 @@ using FixedPointNumbers
 function test_op{F,T}(fun::F, ::Type{T}, fx, fy, fxf, fyf, tol)
     # Make sure that the result is representable
     (typemin(T) <= fun(fxf, fyf) <= typemax(T)) || return nothing
-    @test abs(fun(fx, fy) - convert(T, fun(fxf, fyf))) <= tol
-    @test abs(convert(Float64, fun(fx, fy)) - fun(fxf, fyf)) <= tol
+    @assert abs(fun(fx, fy) - convert(T, fun(fxf, fyf))) <= tol
+    @assert abs(convert(Float64, fun(fx, fy)) - fun(fxf, fyf)) <= tol
 end
 
 function test_fixed{T}(::Type{T}, f)
@@ -36,16 +36,16 @@ function test_fixed{T}(::Type{T}, f)
             fy = convert(T,y)
             fyf = convert(Float64, fy)
 
-            @test fx==fy || x!=y
-            @test fx<fy  || x>=y
-            @test fx<=fy || x>y
+            @assert fx==fy || x!=y
+            @assert fx<fy  || x>=y
+            @assert fx<=fy || x>y
 
             test_op(+, T, fx, fy, fxf, fyf, tol)
             test_op(-, T, fx, fy, fxf, fyf, tol)
             test_op(*, T, fx, fy, fxf, fyf, tol)
             fy != 0 && test_op(/, T, fx, fy, fxf, fyf, tol)
 
-            @test isequal(fx,fy) == isequal(hash(fx),hash(fy))
+            @assert isequal(fx,fy) == isequal(hash(fx),hash(fy))
         end
     end
 end

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -66,3 +66,9 @@ a = F6[1.2, 1.4]
 acmp = Float64(a[1])*Float64(a[2])
 @test prod(a) == acmp
 @test prod(a, 1) == [acmp]
+
+x = Fixed{Int8,8}(0.3)
+for T in (Float16, Float32, Float64, BigFloat)
+    y = convert(T, x)
+    @test isa(y, T)
+end

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -1,6 +1,13 @@
 using Base.Test
 using FixedPointNumbers
 
+function test_op{F,T}(fun::F, ::Type{T}, fx, fy, fxf, fyf, tol)
+    # Make sure that the result is representable
+    (typemin(T) <= fun(fxf, fyf) <= typemax(T)) || return nothing
+    @test abs(fun(fx, fy) - convert(T, fun(fxf, fyf))) <= tol
+    @test abs(convert(Float64, fun(fx, fy)) - fun(fxf, fyf)) <= tol
+end
+
 function test_fixed{T}(::Type{T}, f)
     values = [-10:0.01:10; -180:.01:-160; 160:.01:180]
     tol = 2.0^-f
@@ -33,15 +40,10 @@ function test_fixed{T}(::Type{T}, f)
             @test fx<fy  || x>=y
             @test fx<=fy || x>y
 
-            for fun in (+, -, *, /)
-                # Make sure that the result is representable
-                if !(typemin(T) <= fun(fxf, fyf) <= typemax(T))
-                    continue
-                elseif (fun == /) && fy != 0
-                    @test abs(fun(fx, fy) - convert(T, fun(fxf, fyf))) <= tol
-                    @test abs(convert(Float64, fun(fx, fy)) - fun(fxf, fyf)) <= tol
-                end
-            end
+            test_op(+, T, fx, fy, fxf, fyf, tol)
+            test_op(-, T, fx, fy, fxf, fyf, tol)
+            test_op(*, T, fx, fy, fxf, fyf, tol)
+            fy != 0 && test_op(/, T, fx, fy, fxf, fyf, tol)
 
             @test isequal(fx,fy) == isequal(hash(fx),hash(fy))
         end

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -160,3 +160,9 @@ a = UFixed14[3.2, 2.4]
 acmp = Float64(a[1])*Float64(a[2])
 @test prod(a) == acmp
 @test prod(a, 1) == [acmp]
+
+x = UFixed8(0.3)
+for T in (Float16, Float32, Float64, BigFloat)
+    y = convert(T, x)
+    @test isa(y, T)
+end


### PR DESCRIPTION
Curiously, currently we have this:
```jl
julia> using FixedPointNumbers

julia> x = UFixed8(0.3)
UFixed8(0.298)

julia> y = convert(Float16, x)
0.29803923f0

julia> typeof(y)
Float32
```
As @vchuravy knows well, that may soon be fixed on julia master (see https://github.com/JuliaLang/julia/pull/17297), but since this package also supports julia 0.4 it seems sensible to fix it here.

I also was reminded about how awfully slow the tests are. Poking at this a bit, I discovered that changing two characters (see 06b6372) speeds up the tests by several fold. Moreover, I suspect there's more improvement possible, because [this loop](https://github.com/JeffBezanson/FixedPointNumbers.jl/blob/f1bafe33e7da24e58edf5c10d49151a0bf4cde96/test/fixed.jl#L37-L43) isn't type-stable, even on julia-0.5 (the type of `fun` is changing on each iteration). However, I confess I'm having trouble understanding the purpose of that loop: as far as I can tell, it only ever runs the tests for `fun == /`. @vchuravy, can you shed some light on this? I'm guessing you meant to run the two lines with `@test` for all 4 functions, skipping it for `/` when `fy == 0`, right?
