### PR TITLE
Fix vectorize function depwarn on 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
     - osx
 julia:
     - 0.4
+    - 0.5
     - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.7.14
+Compat 0.9.1

--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -51,11 +51,11 @@ ufixed12(x) = convert(UFixed12, x)
 ufixed14(x) = convert(UFixed14, x)
 ufixed16(x) = convert(UFixed16, x)
 
-@vectorize_1arg Real ufixed8
-@vectorize_1arg Real ufixed10
-@vectorize_1arg Real ufixed12
-@vectorize_1arg Real ufixed14
-@vectorize_1arg Real ufixed16
+Compat.@dep_vectorize_1arg Real ufixed8
+Compat.@dep_vectorize_1arg Real ufixed10
+Compat.@dep_vectorize_1arg Real ufixed12
+Compat.@dep_vectorize_1arg Real ufixed14
+Compat.@dep_vectorize_1arg Real ufixed16
 
 
 convert(::Type{BigFloat}, x::UFixed) = reinterpret(x)*(1/BigFloat(rawone(x)))

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -1,4 +1,6 @@
-using FixedPointNumbers, Base.Test
+using FixedPointNumbers
+using Base.Test
+using Compat
 
 @test reinterpret(0xa2uf8)  == 0xa2
 @test reinterpret(0xa2uf10) == 0xa2
@@ -15,7 +17,9 @@ using FixedPointNumbers, Base.Test
 @test ufixed8(1.0) == 0xffuf8
 @test ufixed8(0.5) == 0x80uf8
 @test ufixed14(1.0) == 0x3fffuf14
-@test ufixed12([2]) == UFixed12[0x1ffeuf12]
+v = @compat ufixed12.([2])
+@test v == UFixed12[0x1ffeuf12]
+@test isa(v, Vector{UFixed12})
 
 UF2 = (UFixed{UInt32,16}, UFixed{UInt64,3}, UFixed{UInt128,7})
 


### PR DESCRIPTION
Requires https://github.com/JuliaLang/Compat.jl/pull/280 and a new `Compat` tag.