### PR TITLE
Add unchecked conversions

### DIFF
--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -34,6 +34,9 @@ convert{T,f}(::Type{Fixed{T,f}}, x::Integer) = Fixed{T,f}(round(T, convert(widen
 convert{T,f}(::Type{Fixed{T,f}}, x::AbstractFloat) = Fixed{T,f}(round(T, trunc(widen1(T),x)<<f + rem(x,1)*(1<<f)),0)
 convert{T,f}(::Type{Fixed{T,f}}, x::Rational) = Fixed{T,f}(x.num)/Fixed{T,f}(x.den)
 
+rem{T,f}(x::Integer, ::Type{Fixed{T,f}}) = Fixed{T,f}(rem(x,T)<<f,0)
+rem{T,f}(x::Real,    ::Type{Fixed{T,f}}) = Fixed{T,f}(rem(Integer(trunc(x)),T)<<f + rem(Integer(round(rem(x,1)*(1<<f))),T),0)
+
 convert{T,f}(::Type{BigFloat}, x::Fixed{T,f}) =
     convert(BigFloat,x.i>>f) + convert(BigFloat,x.i&(1<<f - 1))/convert(BigFloat,1<<f)
 convert{TF<:AbstractFloat,T,f}(::Type{TF}, x::Fixed{T,f}) =

--- a/src/ufixed.jl
+++ b/src/ufixed.jl
@@ -47,6 +47,9 @@ convert{U<:UFixed}(::Type{U}, x::Real) = _convert(U, rawtype(U), x)
 _convert{U<:UFixed,T}(::Type{U}, ::Type{T}, x)       = U(round(T, widen1(rawone(U))*x), 0)
 _convert{U<:UFixed  }(::Type{U}, ::Type{UInt128}, x) = U(round(UInt128, rawone(U)*x), 0)
 
+rem{T<:UFixed}(x::T, ::Type{T}) = x
+rem{T<:UFixed}(x::UFixed, ::Type{T}) = reinterpret(T, rem(unsafe_trunc(UInt, round((rawone(T)/rawone(x))*reinterpret(x))), rawtype(T)))
+rem{T<:UFixed}(x::Real, ::Type{T}) = reinterpret(T, rem(unsafe_trunc(Int, round(rawone(T)*x)), rawtype(T)))
 
 convert(::Type{BigFloat}, x::UFixed) = reinterpret(x)*(1/BigFloat(rawone(x)))
 function convert{T<:AbstractFloat}(::Type{T}, x::UFixed)

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -64,6 +64,20 @@ for (TI, f) in [(Int8, 8), (Int16, 8), (Int16, 10), (Int32, 16)]
     test_fixed(T, f)
 end
 
+T = Fixed{Int8,7}
+for i = -1.0:0.1:typemax(T)
+    @test i % T === T(i)
+end
+@test ( 1.5 % T).i == round(Int,  1.5*128) % Int8
+@test (-0.3 % T).i == round(Int, -0.3*128) % Int8
+
+T = Fixed{Int16,9}
+for i = -64.0:0.1:typemax(T)
+    @test i % T === T(i)
+end
+@test ( 65.2 % T).i == round(Int,  65.2*512) % Int16
+@test (-67.2 % T).i == round(Int, -67.2*512) % Int16
+
 # reductions
 F8 = Fixed{Int8,8}
 a = F8[0.498, 0.1]

--- a/test/ufixed.jl
+++ b/test/ufixed.jl
@@ -81,6 +81,18 @@ for T in (FixedPointNumbers.UF..., UF2...)
 end
 @test convert(Rational, convert(UFixed8, 0.5)) == 0x80//0xff
 
+for i = 0.0:0.1:1.0
+    @test i % UFixed8 === UFixed8(i)
+end
+@test ( 1.5 % UFixed8).i == round(Int,  1.5*255) % UInt8
+@test (-0.3 % UFixed8).i == round(Int, -0.3*255) % UInt8
+
+for i = 0.0:0.1:64.0
+    @test i % UFixed10 === UFixed10(i)
+end
+@test (65.2 % UFixed10).i == round(Int, 65.2*1023) % UInt16
+@test (-0.3 % UFixed10).i == round(Int, -0.3*1023) % UInt16
+
 x = UFixed8(0b01010001, 0)
 @test ~x == UFixed8(0b10101110, 0)
 @test -x == 0xafuf8


### PR DESCRIPTION
These are most useful in conjunction with pre-checking, for example if you want to return a more informative error than InexactError:

```jl
function gray(x)
    0 <= x <= 1 || throw_converterror(x, UFixed8)
    x % UFixed8
end

@noinline function throw_converterror{T}(x, ::Type{T})
    error("$x is not between $(oftype(x, typemin(T))) and $(oftype(x, typemax(T))) and cannot be converted to type $T")
end
```
The performance of `gray` is within spitting distance of just calling `convert(UFixed8, x)`. I'm going to use this in ColorTypes, since people are perennially confused by this (e.g., https://github.com/JuliaGraphics/Colors.jl/issues/252).
